### PR TITLE
Enhance portfolio dynamics and theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# Andrew
+# Jaime Héctor García González Portfolio
+
+A minimal futuristic portfolio site built with Next.js 13, Tailwind CSS and Framer Motion. The layout follows Apple's clean style with smooth animations.
+
+Features include a header with dark/light mode toggle, animated hero text and a dynamic ideas feed.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  scroll-behavior: smooth;
+  transition: background-color 0.3s, color 0.3s;
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,21 @@
+import './globals.css'
+import { Inter } from 'next/font/google'
+import Header from '../components/Header'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata = {
+  title: 'Jaime Héctor García González',
+  description: 'Portfolio',
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="es" className="scroll-smooth">
+      <body className={`${inter.className} pt-16 bg-white text-gray-900 dark:bg-black dark:text-white`}>
+        <Header />
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,21 @@
+'use client'
+import { motion } from 'framer-motion'
+import Hero from '../components/Hero'
+import Experience from '../components/Experience'
+import Projects from '../components/Projects'
+import Framework from '../components/Framework'
+import Ideas from '../components/Ideas'
+import Contact from '../components/Contact'
+
+export default function Home() {
+  return (
+    <main className="space-y-24">
+      <Hero />
+      <Experience />
+      <Projects />
+      <Framework />
+      <Ideas />
+      <Contact />
+    </main>
+  )
+}

--- a/components/Contact.js
+++ b/components/Contact.js
@@ -1,0 +1,22 @@
+'use client'
+import { useState } from 'react'
+
+export default function Contact() {
+  const [status, setStatus] = useState('')
+  return (
+    <section id="contact" className="container mx-auto px-4 pb-24">
+      <h2 className="text-3xl font-bold mb-8 text-center">Contact</h2>
+      <form onSubmit={(e)=>{e.preventDefault();setStatus('Thanks!')}} className="max-w-md mx-auto space-y-4">
+        <input type="text" placeholder="Name" className="w-full p-2 border rounded" required />
+        <input type="email" placeholder="Email" className="w-full p-2 border rounded" required />
+        <textarea placeholder="Message" className="w-full p-2 border rounded" rows="4" required />
+        <button type="submit" className="w-full bg-primary text-white p-2 rounded">Send</button>
+      </form>
+      {status && <p className="text-center mt-4">{status}</p>}
+      <div className="flex justify-center mt-4 space-x-4">
+        <a href="mailto:example@example.com" className="underline">Email</a>
+        <a href="https://www.linkedin.com" className="underline">LinkedIn</a>
+      </div>
+    </section>
+  )
+}

--- a/components/DarkModeToggle.js
+++ b/components/DarkModeToggle.js
@@ -1,0 +1,29 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export default function DarkModeToggle() {
+  const [dark, setDark] = useState(false)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    setDark(stored ? stored === 'dark' : prefersDark)
+  }, [])
+
+  useEffect(() => {
+    const root = window.document.documentElement
+    if (dark) {
+      root.classList.add('dark')
+      localStorage.setItem('theme', 'dark')
+    } else {
+      root.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
+    }
+  }, [dark])
+
+  return (
+    <button onClick={() => setDark(!dark)} aria-label="Toggle theme" className="text-xl">
+      {dark ? '🌙' : '☀️'}
+    </button>
+  )
+}

--- a/components/Experience.js
+++ b/components/Experience.js
@@ -1,0 +1,26 @@
+'use client'
+import { motion } from 'framer-motion'
+
+const items = [
+  { title: 'Microsoft', desc: 'AI for Education, National Initiatives, Channel Strategy' },
+  { title: 'RuralGuru', desc: 'Gamified rural tourism' },
+  { title: 'Jaleo Rural', desc: 'Nature + landscaping services' },
+  { title: 'Fragments of Silence', desc: 'Transmedia universe visionary' },
+]
+
+export default function Experience() {
+  return (
+    <section id="experience" className="container mx-auto px-4">
+      <h2 className="text-3xl font-bold mb-8 text-center">Experience</h2>
+      <div className="grid md:grid-cols-2 gap-8">
+        {items.map((item, i) => (
+          <motion.div key={i} initial={{ opacity:0, y:20 }} whileInView={{ opacity:1, y:0 }} viewport={{ once:true }} className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-xl font-semibold mb-2">{item.title}</h3>
+            <p>{item.desc}</p>
+          </motion.div>
+        ))}
+      </div>
+      <p className="mt-6 text-center font-semibold">10+ years of high-impact projects — AI meets nature, culture, and storytelling</p>
+    </section>
+  )
+}

--- a/components/Framework.js
+++ b/components/Framework.js
@@ -1,0 +1,26 @@
+'use client'
+import { motion } from 'framer-motion'
+
+const roles = [
+  { title: 'Captain', desc: 'Leader' },
+  { title: 'AI bot', desc: 'Assistant' },
+  { title: 'Mission Ops', desc: 'Execution' },
+  { title: 'Community Linker', desc: 'Partners' },
+  { title: 'Doctor', desc: 'Team health' },
+]
+
+export default function Framework() {
+  return (
+    <section id="frameworks" className="container mx-auto px-4">
+      <h2 className="text-3xl font-bold mb-8 text-center">Team Framework</h2>
+      <div className="flex flex-wrap justify-center gap-6">
+        {roles.map((r, i) => (
+          <motion.div key={i} initial={{ scale:0.8, opacity:0 }} whileInView={{ scale:1, opacity:1 }} viewport={{ once:true }} className="w-40 h-40 bg-gray-100 dark:bg-gray-800 rounded-full flex flex-col items-center justify-center text-center p-4">
+            <span className="font-semibold mb-1">{r.title}</span>
+            <span className="text-sm text-gray-500">{r.desc}</span>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,28 @@
+'use client'
+import DarkModeToggle from './DarkModeToggle'
+
+const links = [
+  { href: '#experience', label: 'Experience' },
+  { href: '#projects', label: 'Projects' },
+  { href: '#frameworks', label: 'Frameworks' },
+  { href: '#ideas', label: 'Ideas' },
+  { href: '#contact', label: 'Contact' },
+]
+
+export default function Header() {
+  return (
+    <header className="fixed top-0 left-0 w-full backdrop-blur bg-white/70 dark:bg-black/70 z-10">
+      <div className="container mx-auto flex items-center justify-between p-4">
+        <span className="font-bold">Jaime HGG</span>
+        <nav className="space-x-4 hidden md:block">
+          {links.map((l) => (
+            <a key={l.href} href={l.href} className="hover:underline">
+              {l.label}
+            </a>
+          ))}
+        </nav>
+        <DarkModeToggle />
+      </div>
+    </header>
+  )
+}

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,0 +1,33 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+
+const tagline = 'AI strategist, systems thinker, narrative architect. Bridging education, technology, and innovation.'
+
+export default function Hero() {
+  const [text, setText] = useState('')
+
+  useEffect(() => {
+    let i = 0
+    const interval = setInterval(() => {
+      setText(tagline.slice(0, i))
+      i++
+      if (i > tagline.length) clearInterval(interval)
+    }, 40)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <section className="h-screen flex flex-col items-center justify-center text-center px-4 bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-900 dark:via-black dark:to-gray-800">
+      <motion.h1 initial={{ opacity:0, y:20 }} animate={{ opacity:1, y:0 }} transition={{ duration:0.8 }} className="text-4xl md:text-6xl font-bold mb-4">
+        Jaime Héctor García González
+      </motion.h1>
+      <motion.h2 initial={{ opacity:0, y:20 }} animate={{ opacity:1, y:0 }} transition={{ duration:1 }} className="text-xl md:text-2xl font-semibold text-primary mb-2">
+        Redesigning systems with intelligence
+      </motion.h2>
+      <motion.p initial={{ opacity:0, y:20 }} animate={{ opacity:1, y:0 }} transition={{ duration:1.2 }} className="max-w-xl min-h-[4rem]">
+        {text}
+      </motion.p>
+    </section>
+  )
+}

--- a/components/Ideas.js
+++ b/components/Ideas.js
@@ -1,0 +1,39 @@
+'use client'
+import { useState } from 'react'
+
+const initialThoughts = [
+  'no sé si hay más gente que…',
+  'innovating at the intersection of AI and rural life',
+]
+
+export default function Ideas() {
+  const [thoughts, setThoughts] = useState(initialThoughts)
+  const [value, setValue] = useState('')
+
+  const addThought = (e) => {
+    e.preventDefault()
+    if (!value.trim()) return
+    setThoughts([value.trim(), ...thoughts])
+    setValue('')
+  }
+
+  return (
+    <section id="ideas" className="container mx-auto px-4">
+      <h2 className="text-3xl font-bold mb-8 text-center">Ideas & Writings</h2>
+      <form onSubmit={addThought} className="flex mb-4">
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Share a thought..."
+          className="flex-1 p-2 border rounded-l"
+        />
+        <button className="bg-primary text-white px-4 rounded-r">Post</button>
+      </form>
+      <ul className="space-y-2">
+        {thoughts.map((t, i) => (
+          <li key={i} className="border-b pb-2">{t}</li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/components/Projects.js
+++ b/components/Projects.js
@@ -1,0 +1,35 @@
+'use client'
+import { motion } from 'framer-motion'
+
+const projects = [
+  { title: 'RuralGuru app', img: '/projects/ruralguru.png' },
+  { title: 'La Casa del Tesoro', img: '/projects/tesoro.png' },
+  { title: 'AI wedding game', img: '/projects/wedding.png' },
+  { title: 'Narrative trilogy', img: '/projects/trilogy.png' },
+  { title: 'Space Station Crew Model', img: '/projects/crew.png' },
+]
+
+export default function Projects() {
+  return (
+    <section id="projects" className="container mx-auto px-4">
+      <h2 className="text-3xl font-bold mb-8 text-center">Projects</h2>
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
+        {projects.map((p, i) => (
+          <motion.div
+            key={i}
+            className="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg"
+            initial={{ opacity:0, y:20 }}
+            whileInView={{ opacity:1, y:0 }}
+            whileHover={{ scale: 1.05 }}
+            viewport={{ once:true }}
+          >
+            <div className="h-40 bg-gray-300 dark:bg-gray-700 rounded mb-2 flex items-center justify-center">
+              <span className="text-gray-500">Image</span>
+            </div>
+            <h3 className="text-lg font-semibold">{p.title}</h3>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true,
+  },
+}
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "framer-motion": "^10.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        primary: '#0ea5e9',
+      },
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- add dark mode toggle with `DarkModeToggle` component
- introduce site header navigation
- animate hero tagline with typewriter effect and gradient background
- make ideas feed interactive and project cards hoverable
- update global transitions and docs

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846023fb6888332bda797337c9ed639